### PR TITLE
added api_build_command in workflow file

### DIFF
--- a/.github/workflows/azure-static-web-apps-white-mushroom-0201c7603.yml
+++ b/.github/workflows/azure-static-web-apps-white-mushroom-0201c7603.yml
@@ -30,6 +30,7 @@ jobs:
           app_location: "/" # App source code path
           api_location: "api" # Api source code path - optional
           app_artifact_location: "dist/sample-angular-on-azure-static-web" # Built app content directory - optional
+          api_build_command: "npm run build -- --prod"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
added api_build_command to build an angular app in prod mode
Useful link for adding custom build commands while deploying on Azure static web app:
https://docs.microsoft.com/en-us/azure/static-web-apps/github-actions-workflow#custom-build-commands
https://docs.microsoft.com/en-us/azure/static-web-apps/front-end-frameworks