### PR TITLE
Added app_build_command with proper value

### DIFF
--- a/.github/workflows/azure-static-web-apps-white-mushroom-0201c7603.yml
+++ b/.github/workflows/azure-static-web-apps-white-mushroom-0201c7603.yml
@@ -30,7 +30,7 @@ jobs:
           app_location: "/" # App source code path
           api_location: "api" # Api source code path - optional
           app_artifact_location: "dist/sample-angular-on-azure-static-web" # Built app content directory - optional
-          api_build_command: "npm run build -- --prod"
+          app_build_command: "npm run build -- --prod"
           ###### End of Repository/Build Configurations ######
 
   close_pull_request_job:


### PR DESCRIPTION
Added correct command app_build_command for building app

In my previous PR, I have added wrong command i.e `api_build_command` which is basically used to build azure function. But in our case, we have to use build Application so we have to use `app_build_command`.  This change will work now.

Sorry for the confusion.